### PR TITLE
Preserve repo casing in snapshots base URL

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -49,11 +49,12 @@ jobs:
           : > public/.nojekyll
           echo "TS=$(date -u +%Y%m%d%H%M%S)" >> "$GITHUB_ENV"
           OWNER_LOWER="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
-          REPO_LOWER="$(echo "${GITHUB_REPOSITORY#*/}" | tr '[:upper:]' '[:lower:]')"
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          REPO_LOWER="$(echo "${REPO_NAME}" | tr '[:upper:]' '[:lower:]')"
           if [ "${REPO_LOWER}" = "${OWNER_LOWER}.github.io" ]; then
             echo "BASE_URL=https://${OWNER_LOWER}.github.io" >> "$GITHUB_ENV"
           else
-            echo "BASE_URL=https://${OWNER_LOWER}.github.io/${REPO_LOWER}" >> "$GITHUB_ENV"
+            echo "BASE_URL=https://${OWNER_LOWER}.github.io/${REPO_NAME}" >> "$GITHUB_ENV"
           fi
 
       - name: 5. Kalender-HTML erstellen


### PR DESCRIPTION
## Summary
- capture the original repository name in the snapshot workflow so its casing is preserved in BASE_URL
- continue using the lowercased repository name only for owner-page comparisons while project paths keep their original casing

## Testing
- manual simulation of the snapshot workflow with an uppercase repository name to confirm safe_fetch.sh retrieves an existing image


------
https://chatgpt.com/codex/tasks/task_e_68ceb274a8d8832b9b86ccafdfd9a205